### PR TITLE
fix errors on installation and using variables to define the username

### DIFF
--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -1,3 +1,4 @@
 -e git+https://github.com/kytos/python-openflow.git#egg=python-openflow
 -e git+https://github.com/kytos/kytos.git#egg=kytos
+-e git+https://github.com/kytos/of_core.git#egg=kytos-of_core
 -e .[dev]

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -7,6 +7,7 @@
 -e git+https://github.com/kytos/kytos.git#egg=kytos  # via -r requirements/dev.in
 -e .
 -e git+https://github.com/kytos/python-openflow.git#egg=python-openflow  # via -r requirements/dev.in, kytos
+-e git+https://github.com/kytos/of_core.git#egg=kytos-of_core
 appdirs==1.4.4            # via virtualenv
 astroid==2.4.2            # via pylint
 backcall==0.1.0           # via ipython, kytos

--- a/setup.py
+++ b/setup.py
@@ -173,6 +173,7 @@ class CITest(TestCommand):
         check_call(cmd, shell=True)
 
 
+# pylint: disable=too-few-public-methods
 class KytosInstall:
     """Common code for all install types."""
 
@@ -229,7 +230,7 @@ class DevelopMode(develop):
             shutil.rmtree(str(ENABLED_PATH), ignore_errors=True)
         else:
             self._create_folder_symlinks()
-            #self._create_file_symlinks()
+            # self._create_file_symlinks()
             KytosInstall.enable_core_napps()
 
     @staticmethod

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ if 'bdist_wheel' in sys.argv:
 BASE_ENV = Path(os.environ.get('VIRTUAL_ENV', '/'))
 
 NAPP_NAME = 'coloring'
+NAPP_USERNAME = 'amlight'
 NAPP_VERSION = '0.1'
 
 # Kytos var folder
@@ -178,23 +179,12 @@ class KytosInstall:
     @staticmethod
     def enable_core_napps():
         """Enable a NAPP by creating a symlink."""
-        (ENABLED_PATH / 'kytos').mkdir(parents=True, exist_ok=True)
+        (ENABLED_PATH / NAPP_USERNAME).mkdir(parents=True, exist_ok=True)
         for napp in CORE_NAPPS:
             napp_path = Path('kytos', napp)
             src = ENABLED_PATH / napp_path
             dst = INSTALLED_PATH / napp_path
             symlink_if_different(src, dst)
-
-    @staticmethod
-    def install_core_napps():
-        """Install a NAPP."""
-        for napp in CORE_NAPPS:
-            napp_path = Path('kytos', napp)
-            dst = INSTALLED_PATH / napp_path
-            dst.mkdir(parents=True, exist_ok=True)
-            install_cmd = \
-                f'git clone https://github.com/kytos/{napp}.git {dst}'
-            check_call(install_cmd, shell=True)
 
 
 class InstallMode(install):
@@ -239,8 +229,7 @@ class DevelopMode(develop):
             shutil.rmtree(str(ENABLED_PATH), ignore_errors=True)
         else:
             self._create_folder_symlinks()
-            # self._create_file_symlinks()
-            KytosInstall.install_core_napps()
+            #self._create_file_symlinks()
             KytosInstall.enable_core_napps()
 
     @staticmethod
@@ -250,25 +239,21 @@ class DevelopMode(develop):
         ./napps/kytos/napp_name will generate a link in
         var/lib/kytos/napps/.installed/kytos/napp_name.
         """
-        links = INSTALLED_PATH / 'kytos'
+        links = INSTALLED_PATH / NAPP_USERNAME
         links.mkdir(parents=True, exist_ok=True)
         code = CURRENT_DIR
         src = links / NAPP_NAME
         symlink_if_different(src, code)
 
-        (ENABLED_PATH / 'amlight').mkdir(parents=True, exist_ok=True)
-        dst = ENABLED_PATH / Path('amlight', NAPP_NAME)
-        symlink_if_different(dst, src)
-
-        (ENABLED_PATH / 'kytos').mkdir(parents=True, exist_ok=True)
-        dst = ENABLED_PATH / Path('kytos', NAPP_NAME)
+        (ENABLED_PATH / NAPP_USERNAME).mkdir(parents=True, exist_ok=True)
+        dst = ENABLED_PATH / Path(NAPP_USERNAME, NAPP_NAME)
         symlink_if_different(dst, src)
 
     @staticmethod
     def _create_file_symlinks():
         """Symlink to required files."""
         src = ENABLED_PATH / '__init__.py'
-        dst = CURRENT_DIR / 'napps' / '__init__.py'
+        dst = CURRENT_DIR / '__init__.py'
         symlink_if_different(src, dst)
 
 
@@ -285,14 +270,14 @@ def symlink_if_different(path, target):
         path.symlink_to(target)
 
 
-setup(name=f'amlight_{NAPP_NAME}',
+setup(name=f'{NAPP_USERNAME}_{NAPP_NAME}',
       version=NAPP_VERSION,
       description='Amlight NApps',
       url='http://github.com/amlight/{NAPP_NAME}',
       author='Amlight Team',
       author_email='antonio@amlight.net',
       license='MIT',
-      install_requires=['setuptools >= 36.0.1'],
+      install_requires=['kytos'],
       setup_requires=['pytest-runner'],
       tests_require=['pytest'],
       extras_require={


### PR DESCRIPTION
Applying some changes to the setup.py so that the installation through pip won't fail.

Tests:
```
$ docker run -it --rm amlight/kytos python3 -m pip install -e git+https://github.com/italovalcy/coloring@fix-issue_5#egg=amlight-coloring
[ ok ] Starting enhanced syslogd: rsyslogd.
Starting Kytos controller: done
Obtaining amlight-coloring from git+https://github.com/italovalcy/coloring@fix-issue_5#egg=amlight-coloring
  Cloning https://github.com/italovalcy/coloring (to revision fix-issue_5) to /src/amlight-coloring
  Running command git clone -q https://github.com/italovalcy/coloring /src/amlight-coloring
  Running command git checkout -b fix-issue_5 --track origin/fix-issue_5
  Switched to a new branch 'fix-issue_5'
  Branch 'fix-issue_5' set up to track remote branch 'fix-issue_5' from 'origin'.
Requirement already satisfied: kytos in /usr/local/lib/python3.7/dist-packages (from amlight-coloring) (2020.2)
Requirement already satisfied: pexpect==4.8.0 in /usr/local/lib/python3.7/dist-packages (from kytos->amlight-coloring) (4.8.0)
Requirement already satisfied: flask==1.1.2 in /usr/local/lib/python3.7/dist-packages (from kytos->amlight-coloring) (1.1.2)
Requirement already satisfied: pygments==2.7.1 in /usr/local/lib/python3.7/dist-packages (from kytos->amlight-coloring) (2.7.1)
Requirement already satisfied: janus==0.4.0 in /usr/local/lib/python3.7/dist-packages (from kytos->amlight-coloring) (0.4.0)
Requirement already satisfied: decorator==4.4.2 in /usr/local/lib/python3.7/dist-packages (from kytos->amlight-coloring) (4.4.2)
Requirement already satisfied: markupsafe==1.1.1 in /usr/local/lib/python3.7/dist-packages (from kytos->amlight-coloring) (1.1.1)
Requirement already satisfied: pickleshare==0.7.5 in /usr/local/lib/python3.7/dist-packages (from kytos->amlight-coloring) (0.7.5)
Requirement already satisfied: docutils==0.16 in /usr/local/lib/python3.7/dist-packages (from kytos->amlight-coloring) (0.16)
Requirement already satisfied: ptyprocess==0.6.0 in /usr/local/lib/python3.7/dist-packages (from kytos->amlight-coloring) (0.6.0)
Requirement already satisfied: watchdog==0.10.2 in /usr/local/lib/python3.7/dist-packages (from kytos->amlight-coloring) (0.10.2)
Requirement already satisfied: wcwidth==0.1.9 in /usr/local/lib/python3.7/dist-packages (from kytos->amlight-coloring) (0.1.9)
Requirement already satisfied: jedi==0.16.0 in /usr/local/lib/python3.7/dist-packages (from kytos->amlight-coloring) (0.16.0)
Requirement already satisfied: werkzeug==1.0.1 in /usr/local/lib/python3.7/dist-packages (from kytos->amlight-coloring) (1.0.1)
Requirement already satisfied: backcall==0.1.0 in /usr/local/lib/python3.7/dist-packages (from kytos->amlight-coloring) (0.1.0)
Requirement already satisfied: ipython==7.13.0 in /usr/local/lib/python3.7/dist-packages (from kytos->amlight-coloring) (7.13.0)
Requirement already satisfied: itsdangerous==1.1.0 in /usr/local/lib/python3.7/dist-packages (from kytos->amlight-coloring) (1.1.0)
Requirement already satisfied: prompt-toolkit==3.0.5 in /usr/local/lib/python3.7/dist-packages (from kytos->amlight-coloring) (3.0.5)
Requirement already satisfied: parso==0.6.2 in /usr/local/lib/python3.7/dist-packages (from kytos->amlight-coloring) (0.6.2)
Requirement already satisfied: flask-socketio==4.2.1 in /usr/local/lib/python3.7/dist-packages (from kytos->amlight-coloring) (4.2.1)
Requirement already satisfied: pyjwt==1.7.1 in /usr/local/lib/python3.7/dist-packages (from kytos->amlight-coloring) (1.7.1)
Requirement already satisfied: flask-cors==3.0.8 in /usr/local/lib/python3.7/dist-packages (from kytos->amlight-coloring) (3.0.8)
Requirement already satisfied: click==7.1.1 in /usr/local/lib/python3.7/dist-packages (from kytos->amlight-coloring) (7.1.1)
Requirement already satisfied: python-openflow==2020.2 in /usr/local/lib/python3.7/dist-packages (from kytos->amlight-coloring) (2020.2)
Requirement already satisfied: traitlets==4.3.3 in /usr/local/lib/python3.7/dist-packages (from kytos->amlight-coloring) (4.3.3)
Requirement already satisfied: jinja2==2.11.1 in /usr/local/lib/python3.7/dist-packages (from kytos->amlight-coloring) (2.11.1)
Requirement already satisfied: six==1.15.0 in /usr/local/lib/python3.7/dist-packages (from kytos->amlight-coloring) (1.15.0)
Requirement already satisfied: pathtools==0.1.2 in /usr/local/lib/python3.7/dist-packages (from kytos->amlight-coloring) (0.1.2)
Requirement already satisfied: ipython-genutils==0.2.0 in /usr/local/lib/python3.7/dist-packages (from kytos->amlight-coloring) (0.2.0)
Requirement already satisfied: python-engineio==3.12.1 in /usr/local/lib/python3.7/dist-packages (from kytos->amlight-coloring) (3.12.1)
Requirement already satisfied: python-daemon==2.2.4 in /usr/local/lib/python3.7/dist-packages (from kytos->amlight-coloring) (2.2.4)
Requirement already satisfied: python-socketio==4.5.1 in /usr/local/lib/python3.7/dist-packages (from kytos->amlight-coloring) (4.5.1)
Requirement already satisfied: lockfile==0.12.2 in /usr/local/lib/python3.7/dist-packages (from kytos->amlight-coloring) (0.12.2)
Requirement already satisfied: setuptools>=18.5 in /usr/local/lib/python3.7/dist-packages (from ipython==7.13.0->kytos->amlight-coloring) (53.0.0)
Installing collected packages: amlight-coloring
  Running setup.py develop for amlight-coloring
Successfully installed amlight-coloring
```

Closes #5 