### PR TITLE
Bumped version 2022.1.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,0 +1,30 @@
+#########
+Changelog
+#########
+All notable changes to the coloring NApp will be documented in this file.
+
+[UNRELEASED] - Under development
+********************************
+Added
+=====
+
+Changed
+=======
+
+Deprecated
+==========
+
+Removed
+=======
+
+Fixed
+=====
+
+Security
+========
+
+[2022.1.0] - 2022-02-08
+***********************
+
+First bumped version
+

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,5 +26,6 @@ Security
 [2022.1.0] - 2022-02-08
 ***********************
 
-First bumped version
-
+Added
+=====
+- Enhanced and standardized setup.py `install_requires` to install pinned dependencies

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "amlight",
   "name": "coloring",
   "description": "NApp to color a network topology",
-  "version": "0.1",
+  "version": "2022.1.0",
   "napp_dependencies": ["amlight/flow_stats", "kytos/flow_manager"],
   "license": "",
   "tags": [],

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ BASE_ENV = Path(os.environ.get('VIRTUAL_ENV', '/'))
 
 NAPP_NAME = 'coloring'
 NAPP_USERNAME = 'amlight'
-NAPP_VERSION = '0.1'
+NAPP_VERSION = '2022.1.0'
 
 # Kytos var folder
 VAR_PATH = BASE_ENV / 'var' / 'lib' / 'kytos'


### PR DESCRIPTION
It turns out we haven't bumped version 2022.1.0 and coloring has been working as intended, it'll have the stable shield once issue #11 is done. 